### PR TITLE
Support adding or updating environment variables in task definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules
 npm-debug.log
 bin
+auth.js
+/coverage

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Sequence of steps performed by the script:
 
 #### Environment Varaiables
 
-For all the container definitions found when looking up your defined `image`, you have the option to add or update environment variables
-for these.
+For all the container definitions found when looking up your defined `image`, you have the option to add or update environment variables for these.
 
 This can be done using the `--env` option.
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,26 @@ Sequence of steps performed by the script:
 1. Register this new task definition with ECS.
 1. Update the service to use this new task definition, triggering a blue/green deployment.
 
+#### Environment Varaiables
+
+For all the container definitions found when looking up your defined `image`, you have the option to add or update environment variables
+for these.
+
+This can be done using the `--env` option.
+
+    --env "SERVICE_URL=http://api.somedomain.com"
+
+You can supply as many of these as required.
+
 #### Spare Capacity
 
 In order to roll a blue/green deployment there must be spare capacity available to spin up a task based on your updated task definition.
 If there's not capacity to do this your deployment will fail.
 
-An alternate option provided by this tool is `--kill-task`. This will attempt to stop an existing task, making way for the blue/green rollout.
+This can be done via ECS service `minimum healthy percent` but as a brute force option this tool supports `--kill-task`.
+This will attempt to stop an existing task, making way for the blue/green rollout.
 
-This has obvious implications, reducing your horizontal scale by one during the deployment. If you're only running a single task
-you'll experience some down time. **Use at your own risk.**
+If you're only running a single task you'll experience some down time. **Use at your own risk.**
 
 #### Usage
 
@@ -36,6 +47,7 @@ you'll experience some down time. **Use at your own risk.**
     -i, --image <i>           docker image for task definition, or via AWS_ECS_TASK_IMAGE env variable
     -t, --timeout <t>         max timeout (sec) for ECS service to launch new task, defaults to 90s
     -v, --verbose             enable verbose mode
+    -e, --env <e>             environment variable in "<key>=<value>" format  
     --kill-task               stop a running task to allow space for a rolling blue/green deployment
 
 ##### Node
@@ -52,6 +64,8 @@ ecs-task-deploy \
     -c 'qa' \
     -n 'website-service' \
     -i '44444444.ddd.ecr.us-east-1.amazonaws.com/website:1.0.2' \
+    -e 'SERVICE_URL=http://api.somedomain.com' \
+    -e 'API_KEY=clientapikey' \
     -v
 ```
 
@@ -69,7 +83,10 @@ ecsTaskDeploy({
   cluster: 'cache-cluster',
   service: 'cache-service',
   image: 'redis:2.8',
-  killTask: true
+  env: {
+    SERVICE_URL: 'http://api.somedomain.com',
+    API_KEY: 'clientapikey'
+  }
 })
 .then(
   newTask => console.info(`Task '${newTask.taskDefinitionArn}' created and deployed`), 

--- a/src/index.js
+++ b/src/index.js
@@ -76,9 +76,9 @@ function newTaskDefinition(template, options) {
     containerDefinitions
   }
 }
-/**
- * Overwrites an env variable if it exists, adds it if it doesn't
- */
+/*
+Overwrites an env variable if it exists, adds it if it doesn't
+*/
 function getEnvVariables(existing, options) {
   if (!options.env.length) return existing
   const vars = existing || []

--- a/src/run.js
+++ b/src/run.js
@@ -16,11 +16,22 @@ program
   .option('-i, --image <i>', 'docker image to use in new task definition e.g. user/image:tag, can be defined via AWS_ECS_TASK_IMAGE env variable', String, env.AWS_ECS_TASK_IMAGE)
   .option('-t, --timeout <t>', 'maximum timeout (sec) to wait for ECS service to launch new task, defaults to 180', parseInt, '180')
   .option('-v, --verbose', 'enable verbose mode')
+  .option('-e, --env <e>', 'environment variable in "<key>=<value>" format', toKvps, {})
   .option('--kill-task', 'stop a running task to allow space for a rolling blue/green deployment')
   .parse(process.argv)
 
 execute(program)
   .then(newTask => complete(newTask), e => error(e))
+
+
+function toKvps(val, map) {
+  const i = val.indexOf('=')
+  if (i < 1) return map
+  const name = val.slice(0, i)
+  const value = val.slice(i+1)
+  map[key] = value
+  return map
+}
 
 function complete(newTask) {
   console.info(chalk.bold.cyan(`task '${newTask.taskDefinitionArn}' created and deployed`))

--- a/src/run.js
+++ b/src/run.js
@@ -29,7 +29,7 @@ function toKvps(val, map) {
   if (i < 1) return map
   const name = val.slice(0, i)
   const value = val.slice(i+1)
-  map[key] = value
+  map[name] = value
   return map
 }
 


### PR DESCRIPTION
For all the container definitions found when looking up your defined `image`, you now have the option to add or update environment variables for these.

This can be done using the `--env` option.

    --env "SERVICE_URL=http://api.somedomain.com"

You can supply as many of these as required.