### PR TITLE
Copying over the taskRoleArn to the new definition.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ function newTaskDefinition(template, options) {
     family: template.family,
     volumes: template.volumes,
     containerDefinitions,
-	  taskRoleArn: template.taskRoleArn
+    taskRoleArn: template.taskRoleArn
   }
 }
 /*

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ function verifyOptions(options) {
     options.env = options.env
         ? Object.keys(options.env).map(name => ({ name, value: options.env[name] }))
         : []
-  
+
     return Promise.resolve(options)
   } catch(e) {
     return Promise.reject(e)
@@ -73,7 +73,8 @@ function newTaskDefinition(template, options) {
   return {
     family: template.family,
     volumes: template.volumes,
-    containerDefinitions
+    containerDefinitions,
+	  taskRoleArn: template.taskRoleArn
   }
 }
 /*


### PR DESCRIPTION
Our tasks run under specific IAM roles, without this line the taskRoleArn gets blanked out when a new task definition is created.

It almost feels like the return{} of the newTaskDefinition function should be configurable from the CLI. 
