### PR TITLE
Better error message when service is not found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,10 @@ function deployTaskDefinition(options) {
 function getService(ecs, options) {
   return ecs.describeServices({ cluster: options.cluster, services: [ options.service ] }).promise()
       .then(res => res.data.services.find(service => service.serviceName == options.service))
+      .then(service => {
+         assert.ok(service, `Service ${options.service} not found, aborting.`)
+         return service
+      })
 }
 
 function getActiveTaskDefinition(ecs, service, options) {

--- a/src/index.js
+++ b/src/index.js
@@ -49,8 +49,8 @@ function getService(ecs, options) {
   return ecs.describeServices({ cluster: options.cluster, services: [ options.service ] }).promise()
       .then(res => res.data.services.find(service => service.serviceName == options.service))
       .then(service => {
-         assert.ok(service, `Service ${options.service} not found, aborting.`)
-         return service
+        assert.ok(service, `Service ${options.service} not found, aborting.`)
+        return service
       })
 }
 


### PR DESCRIPTION
If the service is missing the error shown is:
```
Cannot read property 'taskDefinition' of undefined
```

This PR changes the error message to:
```
Service my-service-name not found, aborting.
```